### PR TITLE
Action button fits more tightly into the masthead.  

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -52,12 +52,13 @@ const App = () =>
           <div className="container text-center">
             <div className="intro-text">
               <div className="intro-heading">Housing Data Coalition</div>
-
+              <br/>
+              <div className="btn btn-warning btn-lg">
+                <a class="black" href="#helpdesk">
+                  <strong>NEW:</strong> Send us a data request
+                </a>
+              </div>
             </div>
-            <br/>
-              <a href="#helpdesk">
-              <div className="btn btn-warning btn-lg"><b>NEW:</b> Send us a data request</div>
-            </a>
           </div>
         </header>
 

--- a/src/styles/agency.css
+++ b/src/styles/agency.css
@@ -11,6 +11,16 @@
   }
 }
 
+a.black {
+  color: black;
+}
+a.black.active,
+a.black:active,
+a.black:focus,
+a.black:hover {
+  color: white;
+}
+
 /* AGENCY THEME */
 body {
   overflow-x: hidden;


### PR DESCRIPTION
Reduces Overlap error seen below 
If this is still an issue, we can continue to reduce or modify the `<div>` layout
Also changed hover color of button.  
![OperaOverlap](https://user-images.githubusercontent.com/1453956/106365581-80642d80-6304-11eb-9cbc-94e2a9eef082.png)
