### PR TITLE
remove helpdesk button from homepage

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -52,12 +52,6 @@ const App = () =>
           <div className="container text-center">
             <div className="intro-text">
               <div className="intro-heading">Housing Data Coalition</div>
-              <br/>
-              <div className="btn btn-warning btn-lg">
-                <a class="black" href="#helpdesk">
-                  <strong>NEW:</strong> Send us a data request
-                </a>
-              </div>
             </div>
           </div>
         </header>


### PR DESCRIPTION
At last month's meeting we decided to take a bit of a break over the summer, and will be discussing the future of the data helpdesk afterwards. In the meantime we are removing the "ask helpdesk" button from top landing page of the website (while leaving the one lower down with the full description.